### PR TITLE
`install.sh:fetch`: don't use `rm -rf` with variable arguments

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -98,7 +98,7 @@ fetch_xz() {
 		&& echo "== unpacking" \
 		&& tar -xJf $tarball \
 		&& echo "== removing tarball" \
-		&& rm -fr $tarball \
+		&& rm $tarball \
 		&& make_install $dir
 }
 

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -83,7 +83,7 @@ fetch() {
 		&& echo "== unpacking" \
 		&& tar -zxf $tarball \
 		&& echo "== removing tarball" \
-		&& rm -fr $tarball \
+		&& rm $tarball \
 		&& make_install $dir $2
 }
 


### PR DESCRIPTION
### Purposes
- Prevents massive filesystem destruction if root directory is passed.
- The argument is the `basename` of the Uniform Resource Identifier passed to `curl`, which `curl` should not store as **RO** (thus no `-f` flag needed to remove).
- The argument is a single file (thus no `-r` flag needed to remove).